### PR TITLE
docs: document the public API as TSDoc (generated from type declarations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,562 @@ npm i bare-zlib
 ## License
 
 Apache-2.0
+
+<!-- bare-refgen:api start -->
+
+## API
+
+### Zlib
+
+#### `Zlib.constants`
+
+```ts
+Zlib.constants: {
+  Z_NO_FLUSH: number
+  Z_PARTIAL_FLUSH: number
+  Z_SYNC_FLUSH: number
+  Z_FULL_FLUSH: number
+  Z_FINISH: number
+  Z_BLOCK: number
+  Z_TREES: number
+
+  Z_FILTERED: number
+  Z_HUFFMAN_ONLY: number
+  Z_RLE: number
+  Z_FIXED: number
+  Z_DEFAULT_STRATEGY: number
+
+  Z_NO_COMPRESSION: number
+  Z_BEST_SPEED: number
+  Z_BEST_COMPRESSION: number
+  Z_DEFAULT_COMPRESSION: number
+
+  Z_MIN_CHUNK: number
+  Z_MAX_CHUNK: number
+  Z_DEFAULT_CHUNK: number
+
+  Z_MIN_MEMLEVEL: number
+  Z_MAX_MEMLEVEL: number
+  Z_DEFAULT_MEMLEVEL: number
+
+  Z_MIN_LEVEL: number
+  Z_MAX_LEVEL: number
+  Z_DEFAULT_LEVEL: number
+
+  Z_MIN_WINDOWBITS: number
+  Z_MAX_WINDOWBITS: number
+  Z_DEFAULT_WINDOWBITS: number
+
+  Z_OK: number
+  Z_STREAM_END: number
+  Z_NEED_DICT: number
+  Z_ERRNO: number
+  Z_STREAM_ERROR: number
+  Z_DATA_ERROR: number
+  Z_MEM_ERROR: number
+  Z_BUF_ERROR: number
+  Z_VERSION_ERROR: number
+}
+```
+
+Zlib-related constants such as flush modes, compression levels, strategies, and chunk/window/memory-level bounds.
+
+#### `Zlib.createDeflate(opts?: ZlibOptions): Deflate`
+
+Create and return a new `Deflate` stream for streaming zlib compression.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+#### `Zlib.createDeflateRaw(opts?: ZlibOptions): DeflateRaw`
+
+Create and return a new `DeflateRaw` stream for streaming raw deflate compression, without a zlib header.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+#### `Zlib.createGunzip(opts?: ZlibOptions): Gunzip`
+
+Create and return a new `Gunzip` stream for streaming gzip decompression.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+#### `Zlib.createGzip(opts?: ZlibOptions): Gzip`
+
+Create and return a new `Gzip` stream for streaming gzip compression.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+#### `Zlib.createInflate(opts?: ZlibOptions): Inflate`
+
+Create and return a new `Inflate` stream for streaming zlib decompression.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+#### `Zlib.createInflateRaw(opts?: ZlibOptions): InflateRaw`
+
+Create and return a new `InflateRaw` stream for streaming raw deflate decompression, without a zlib header.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+#### `Zlib.deflate(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void`
+
+Compress `buffer` with deflate, calling `cb` with the resulting `Buffer`.
+
+Overloads:
+
+```ts
+Zlib.deflate(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
+Zlib.deflate(buffer: ZlibInput, cb: ZlibCallback): void
+```
+
+**Parameters**
+
+| Parameter | Type           | Default | Description                                                                  |
+| --------- | -------------- | ------- | ---------------------------------------------------------------------------- |
+| `buffer`  | `ZlibInput`    | —       | The data to compress.                                                        |
+| `opts`    | `ZlibOptions`  | —       | The zlib options to apply for this operation.                                |
+| `cb`      | `ZlibCallback` | —       | Called with the resulting `Buffer`, or with an error if the operation fails. |
+
+#### `Zlib.deflateRaw(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void`
+
+Compress `buffer` with raw deflate, without a zlib header, calling `cb` with the resulting `Buffer`.
+
+Overloads:
+
+```ts
+Zlib.deflateRaw(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
+Zlib.deflateRaw(buffer: ZlibInput, cb: ZlibCallback): void
+```
+
+**Parameters**
+
+| Parameter | Type           | Default | Description                                                                  |
+| --------- | -------------- | ------- | ---------------------------------------------------------------------------- |
+| `buffer`  | `ZlibInput`    | —       | The data to compress.                                                        |
+| `opts`    | `ZlibOptions`  | —       | The zlib options to apply for this operation.                                |
+| `cb`      | `ZlibCallback` | —       | Called with the resulting `Buffer`, or with an error if the operation fails. |
+
+#### `Zlib.deflateRawSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer`
+
+Synchronously compress `buffer` with raw deflate, without a zlib header, and return the resulting `Buffer`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                                |
+| --------- | ------------- | ------- | ---------------------------------------------------------- |
+| `buffer`  | `ZlibInput`   | —       | The data to compress; a string is converted to a `Buffer`. |
+| `opts?`   | `ZlibOptions` | —       | The zlib options to apply for this operation.              |
+
+**Throws**
+
+- `LIMIT_EXCEEDED` — the output exceeded `maxOutputLength`.
+- `ZlibError` — the underlying zlib operation failed; `code` identifies the failure.
+
+#### `Zlib.deflateSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer`
+
+Synchronously compress `buffer` with deflate and return the resulting `Buffer`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                                |
+| --------- | ------------- | ------- | ---------------------------------------------------------- |
+| `buffer`  | `ZlibInput`   | —       | The data to compress; a string is converted to a `Buffer`. |
+| `opts?`   | `ZlibOptions` | —       | The zlib options to apply for this operation.              |
+
+**Throws**
+
+- `LIMIT_EXCEEDED` — the output exceeded `maxOutputLength`.
+- `ZlibError` — the underlying zlib operation failed; `code` identifies the failure.
+
+#### `Zlib.gunzip(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void`
+
+Decompress `buffer` as gzip, calling `cb` with the resulting `Buffer`.
+
+Overloads:
+
+```ts
+Zlib.gunzip(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
+Zlib.gunzip(buffer: ZlibInput, cb: ZlibCallback): void
+```
+
+**Parameters**
+
+| Parameter | Type           | Default | Description                                                                  |
+| --------- | -------------- | ------- | ---------------------------------------------------------------------------- |
+| `buffer`  | `ZlibInput`    | —       | The data to decompress.                                                      |
+| `opts`    | `ZlibOptions`  | —       | The zlib options to apply for this operation.                                |
+| `cb`      | `ZlibCallback` | —       | Called with the resulting `Buffer`, or with an error if the operation fails. |
+
+#### `Zlib.gunzipSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer`
+
+Synchronously decompress `buffer` as gzip and return the resulting `Buffer`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                                  |
+| --------- | ------------- | ------- | ------------------------------------------------------------ |
+| `buffer`  | `ZlibInput`   | —       | The data to decompress; a string is converted to a `Buffer`. |
+| `opts?`   | `ZlibOptions` | —       | The zlib options to apply for this operation.                |
+
+**Throws**
+
+- `LIMIT_EXCEEDED` — the output exceeded `maxOutputLength`.
+- `ZlibError` — the underlying zlib operation failed; `code` (such as `DATA_ERROR`) identifies the failure.
+
+#### `Zlib.gzip(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void`
+
+Compress `buffer` as gzip, calling `cb` with the resulting `Buffer`.
+
+Overloads:
+
+```ts
+Zlib.gzip(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
+Zlib.gzip(buffer: ZlibInput, cb: ZlibCallback): void
+```
+
+**Parameters**
+
+| Parameter | Type           | Default | Description                                                                  |
+| --------- | -------------- | ------- | ---------------------------------------------------------------------------- |
+| `buffer`  | `ZlibInput`    | —       | The data to compress.                                                        |
+| `opts`    | `ZlibOptions`  | —       | The zlib options to apply for this operation.                                |
+| `cb`      | `ZlibCallback` | —       | Called with the resulting `Buffer`, or with an error if the operation fails. |
+
+#### `Zlib.gzipSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer`
+
+Synchronously compress `buffer` as gzip and return the resulting `Buffer`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                                |
+| --------- | ------------- | ------- | ---------------------------------------------------------- |
+| `buffer`  | `ZlibInput`   | —       | The data to compress; a string is converted to a `Buffer`. |
+| `opts?`   | `ZlibOptions` | —       | The zlib options to apply for this operation.              |
+
+**Throws**
+
+- `LIMIT_EXCEEDED` — the output exceeded `maxOutputLength`.
+- `ZlibError` — the underlying zlib operation failed; `code` identifies the failure.
+
+#### `Zlib.inflate(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void`
+
+Decompress `buffer` with inflate, calling `cb` with the resulting `Buffer`.
+
+Overloads:
+
+```ts
+Zlib.inflate(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
+Zlib.inflate(buffer: ZlibInput, cb: ZlibCallback): void
+```
+
+**Parameters**
+
+| Parameter | Type           | Default | Description                                                                  |
+| --------- | -------------- | ------- | ---------------------------------------------------------------------------- |
+| `buffer`  | `ZlibInput`    | —       | The data to decompress.                                                      |
+| `opts`    | `ZlibOptions`  | —       | The zlib options to apply for this operation.                                |
+| `cb`      | `ZlibCallback` | —       | Called with the resulting `Buffer`, or with an error if the operation fails. |
+
+#### `Zlib.inflateRaw(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void`
+
+Decompress `buffer` with raw inflate, without a zlib header, calling `cb` with the resulting `Buffer`.
+
+Overloads:
+
+```ts
+Zlib.inflateRaw(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
+Zlib.inflateRaw(buffer: ZlibInput, cb: ZlibCallback): void
+```
+
+**Parameters**
+
+| Parameter | Type           | Default | Description                                                                  |
+| --------- | -------------- | ------- | ---------------------------------------------------------------------------- |
+| `buffer`  | `ZlibInput`    | —       | The data to decompress.                                                      |
+| `opts`    | `ZlibOptions`  | —       | The zlib options to apply for this operation.                                |
+| `cb`      | `ZlibCallback` | —       | Called with the resulting `Buffer`, or with an error if the operation fails. |
+
+#### `Zlib.inflateRawSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer`
+
+Synchronously decompress `buffer` with raw inflate, without a zlib header, and return the resulting `Buffer`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                                  |
+| --------- | ------------- | ------- | ------------------------------------------------------------ |
+| `buffer`  | `ZlibInput`   | —       | The data to decompress; a string is converted to a `Buffer`. |
+| `opts?`   | `ZlibOptions` | —       | The zlib options to apply for this operation.                |
+
+**Throws**
+
+- `LIMIT_EXCEEDED` — the output exceeded `maxOutputLength`.
+- `ZlibError` — the underlying zlib operation failed; `code` (such as `DATA_ERROR`) identifies the failure.
+
+#### `Zlib.inflateSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer`
+
+Synchronously decompress `buffer` with inflate and return the resulting `Buffer`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                                  |
+| --------- | ------------- | ------- | ------------------------------------------------------------ |
+| `buffer`  | `ZlibInput`   | —       | The data to decompress; a string is converted to a `Buffer`. |
+| `opts?`   | `ZlibOptions` | —       | The zlib options to apply for this operation.                |
+
+**Throws**
+
+- `LIMIT_EXCEEDED` — the output exceeded `maxOutputLength`.
+- `ZlibError` — the underlying zlib operation failed; `code` (such as `DATA_ERROR`) identifies the failure.
+
+#### `Zlib.ZlibInput`
+
+```ts
+type ZlibInput = string | Buffer | Uint8Array
+```
+
+The input accepted by the one-shot functions: a string, `Buffer`, or `Uint8Array`.
+
+### ZlibStream
+
+#### `flush(mode?: number, cb?: ZlibFlushCallback): Promise<void>`
+
+Flush queued data through the stream immediately using the given flush `mode`, resolving once it has drained.
+
+Overloads:
+
+```ts
+flush(mode?: number, cb?: ZlibFlushCallback): Promise<void>
+flush(cb: ZlibFlushCallback): Promise<void>
+```
+
+**Parameters**
+
+| Parameter | Type                | Default | Description                                                                                        |
+| --------- | ------------------- | ------- | -------------------------------------------------------------------------------------------------- |
+| `mode?`   | `number`            | —       | The flush mode, from `constants` (default `Z_FULL_FLUSH`).                                         |
+| `cb?`     | `ZlibFlushCallback` | —       | Called once the flush completes, for Node.js compatibility; the returned promise resolves as well. |
+
+#### `reset(): void`
+
+Reset the underlying compressor or decompressor to its initial state.
+
+**Throws**
+
+- `STREAM_CLOSED` — the stream has already closed.
+
+### Deflate
+
+#### `new Deflate(opts?: ZlibOptions)`
+
+Create a `Deflate` stream with the given `opts`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+### Inflate
+
+#### `new Inflate(opts?: ZlibOptions)`
+
+Create an `Inflate` stream with the given `opts`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+### DeflateRaw
+
+#### `new DeflateRaw(opts?: ZlibOptions)`
+
+Create a `DeflateRaw` stream with the given `opts`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+### InflateRaw
+
+#### `new InflateRaw(opts?: ZlibOptions)`
+
+Create an `InflateRaw` stream with the given `opts`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+### Gzip
+
+#### `new Gzip(opts?: ZlibOptions)`
+
+Create a `Gzip` stream with the given `opts`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+### Gunzip
+
+#### `new Gunzip(opts?: ZlibOptions)`
+
+Create a `Gunzip` stream with the given `opts`.
+
+**Parameters**
+
+| Parameter | Type          | Default | Description                                           |
+| --------- | ------------- | ------- | ----------------------------------------------------- |
+| `opts?`   | `ZlibOptions` | —       | Options for the stream and the underlying zlib state. |
+
+### Types
+
+#### `ZlibOptions`
+
+```ts
+interface ZlibOptions<S extends ZlibStream = ZlibStream> {
+  flush?: number
+  finishFlush?: number
+  chunkSize?: number
+  level?: number
+  windowBits?: number
+  memLevel?: number
+  strategy?: number
+  maxOutputLength?: number
+  transform?(this: S, data: unknown, encoding: StreamEncoding, cb: StreamCallback): void
+  encoding?: BufferEncoding
+  highWaterMark?: number
+  read?(this: S, size: number): void
+  eagerOpen?: boolean
+  signal?: AbortSignal
+  open?(this: S, cb: StreamCallback): void
+  predestroy?(this: S): void
+  destroy?(this: S, err: Error | null, cb: StreamCallback): void
+  write?(this: S, data: unknown, encoding: StreamEncoding, cb: StreamCallback): void
+  writev?(this: S, batch: { chunk: unknown; encoding: StreamEncoding }[], cb: StreamCallback): void
+  final?(this: S, cb: StreamCallback): void
+}
+```
+
+#### `ZlibCallback`
+
+```ts
+interface ZlibCallback {}
+```
+
+Callback for the one-shot asynchronous functions, called with an error or the resulting `Buffer`.
+
+#### `ZlibFlushCallback`
+
+```ts
+interface ZlibFlushCallback {}
+```
+
+Callback invoked once a `flush()` completes.
+
+### Classes
+
+#### `ZlibError`
+
+```ts
+class ZlibError {
+  code: ZlibErrorCode
+  name: 'ZlibError'
+}
+```
+
+## `bare-zlib/constants`
+
+### Constants and variables
+
+#### `constants`
+
+```ts
+constants: {
+  Z_NO_FLUSH: number
+  Z_PARTIAL_FLUSH: number
+  Z_SYNC_FLUSH: number
+  Z_FULL_FLUSH: number
+  Z_FINISH: number
+  Z_BLOCK: number
+  Z_TREES: number
+
+  Z_FILTERED: number
+  Z_HUFFMAN_ONLY: number
+  Z_RLE: number
+  Z_FIXED: number
+  Z_DEFAULT_STRATEGY: number
+
+  Z_NO_COMPRESSION: number
+  Z_BEST_SPEED: number
+  Z_BEST_COMPRESSION: number
+  Z_DEFAULT_COMPRESSION: number
+
+  Z_MIN_CHUNK: number
+  Z_MAX_CHUNK: number
+  Z_DEFAULT_CHUNK: number
+
+  Z_MIN_MEMLEVEL: number
+  Z_MAX_MEMLEVEL: number
+  Z_DEFAULT_MEMLEVEL: number
+
+  Z_MIN_LEVEL: number
+  Z_MAX_LEVEL: number
+  Z_DEFAULT_LEVEL: number
+
+  Z_MIN_WINDOWBITS: number
+  Z_MAX_WINDOWBITS: number
+  Z_DEFAULT_WINDOWBITS: number
+
+  Z_OK: number
+  Z_STREAM_END: number
+  Z_NEED_DICT: number
+  Z_ERRNO: number
+  Z_STREAM_ERROR: number
+  Z_DATA_ERROR: number
+  Z_MEM_ERROR: number
+  Z_BUF_ERROR: number
+  Z_VERSION_ERROR: number
+}
+```
+
+Zlib-related constants such as flush modes, compression levels, strategies, and chunk/window/memory-level bounds.
+
+## `bare-zlib/errors`
+
+### Classes
+
+#### `errors.ZlibError`
+
+An error thrown by a zlib operation, carrying a `code` identifying the underlying zlib failure (such as `DATA_ERROR` or `MEM_ERROR`).
+<!-- bare-refgen:api end -->

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,12 +4,15 @@ import { Transform, TransformOptions, TransformEvents } from 'bare-stream'
 import constants from './lib/constants'
 import ZlibError from './lib/errors'
 
+/** The input accepted by the one-shot functions: a string, `Buffer`, or `Uint8Array`. */
 type ZlibInput = string | Buffer | Uint8Array
 
+/** Callback for the one-shot asynchronous functions, called with an error or the resulting `Buffer`. */
 interface ZlibCallback {
   (err: Error | null, result: Buffer): void
 }
 
+/** Callback invoked once a `flush()` completes. */
 interface ZlibFlushCallback {
   (err: Error | null): void
 }
@@ -18,46 +21,88 @@ interface ZlibOptions<S extends ZlibStream = ZlibStream> extends Omit<
   TransformOptions<S>,
   'flush'
 > {
+  /** The flush mode used for each write, from `zlib.constants` (default `Z_NO_FLUSH`). */
   flush?: number
+  /** The flush mode used when the stream is finished, from `zlib.constants` (default `Z_FINISH`). */
   finishFlush?: number
+  /** The size, in bytes, of the internal processing buffer (default `Z_DEFAULT_CHUNK`). */
   chunkSize?: number
+  /** The compression level, from `zlib.constants.Z_MIN_LEVEL` to `Z_MAX_LEVEL` (default `Z_DEFAULT_LEVEL`). */
   level?: number
+  /** The base-2 logarithm of the window size, from `zlib.constants.Z_MIN_WINDOWBITS` to `Z_MAX_WINDOWBITS` (default `Z_DEFAULT_WINDOWBITS`). */
   windowBits?: number
+  /** The amount of memory allocated for the internal compression state, from `zlib.constants.Z_MIN_MEMLEVEL` to `Z_MAX_MEMLEVEL` (default `Z_DEFAULT_MEMLEVEL`). */
   memLevel?: number
+  /** The compression strategy to use, from `zlib.constants` (default `Z_DEFAULT_STRATEGY`). */
   strategy?: number
+  /** The maximum number of output bytes allowed before the operation throws `LIMIT_EXCEEDED` (defaults to `Buffer.constants.MAX_LENGTH`). */
   maxOutputLength?: number
 }
 
+/** The base `Transform` stream shared by all of the module's compressors and decompressors. */
 interface ZlibStream<M extends TransformEvents = TransformEvents> extends Transform<M> {
+  /**
+   * Flush queued data through the stream immediately using the given flush `mode`, resolving once it has drained.
+   * @param mode - The flush mode, from `constants` (default `Z_FULL_FLUSH`).
+   * @param cb - Called once the flush completes, for Node.js compatibility; the returned promise resolves as well.
+   */
   flush(mode?: number, cb?: ZlibFlushCallback): Promise<void>
   flush(cb: ZlibFlushCallback): Promise<void>
 
+  /**
+   * Reset the underlying compressor or decompressor to its initial state.
+   * @throws {STREAM_CLOSED} the stream has already closed.
+   */
   reset(): void
 }
 
 declare class ZlibStream<M extends TransformEvents = TransformEvents> extends Transform<M> {}
 
 declare class Deflate extends ZlibStream {
+  /**
+   * Create a `Deflate` stream with the given `opts`.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   constructor(opts?: ZlibOptions)
 }
 
 declare class Inflate extends ZlibStream {
+  /**
+   * Create an `Inflate` stream with the given `opts`.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   constructor(opts?: ZlibOptions)
 }
 
 declare class DeflateRaw extends ZlibStream {
+  /**
+   * Create a `DeflateRaw` stream with the given `opts`.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   constructor(opts?: ZlibOptions)
 }
 
 declare class InflateRaw extends ZlibStream {
+  /**
+   * Create an `InflateRaw` stream with the given `opts`.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   constructor(opts?: ZlibOptions)
 }
 
 declare class Gzip extends ZlibStream {
+  /**
+   * Create a `Gzip` stream with the given `opts`.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   constructor(opts?: ZlibOptions)
 }
 
 declare class Gunzip extends ZlibStream {
+  /**
+   * Create a `Gunzip` stream with the given `opts`.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   constructor(opts?: ZlibOptions)
 }
 
@@ -78,36 +123,138 @@ declare namespace Zlib {
     Gunzip
   }
 
+  /**
+   * Create and return a new `Deflate` stream for streaming zlib compression.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   export function createDeflate(opts?: ZlibOptions): Deflate
+  /**
+   * Create and return a new `Inflate` stream for streaming zlib decompression.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   export function createInflate(opts?: ZlibOptions): Inflate
+  /**
+   * Create and return a new `DeflateRaw` stream for streaming raw deflate compression, without a zlib header.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   export function createDeflateRaw(opts?: ZlibOptions): DeflateRaw
+  /**
+   * Create and return a new `InflateRaw` stream for streaming raw deflate decompression, without a zlib header.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   export function createInflateRaw(opts?: ZlibOptions): InflateRaw
+  /**
+   * Create and return a new `Gzip` stream for streaming gzip compression.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   export function createGzip(opts?: ZlibOptions): Gzip
+  /**
+   * Create and return a new `Gunzip` stream for streaming gzip decompression.
+   * @param opts - Options for the stream and the underlying zlib state.
+   */
   export function createGunzip(opts?: ZlibOptions): Gunzip
 
+  /**
+   * Compress `buffer` with deflate, calling `cb` with the resulting `Buffer`.
+   * @param buffer - The data to compress.
+   * @param opts - The zlib options to apply for this operation.
+   * @param cb - Called with the resulting `Buffer`, or with an error if the operation fails.
+   */
   export function deflate(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
   export function deflate(buffer: ZlibInput, cb: ZlibCallback): void
 
+  /**
+   * Decompress `buffer` with inflate, calling `cb` with the resulting `Buffer`.
+   * @param buffer - The data to decompress.
+   * @param opts - The zlib options to apply for this operation.
+   * @param cb - Called with the resulting `Buffer`, or with an error if the operation fails.
+   */
   export function inflate(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
   export function inflate(buffer: ZlibInput, cb: ZlibCallback): void
 
+  /**
+   * Compress `buffer` with raw deflate, without a zlib header, calling `cb` with the resulting `Buffer`.
+   * @param buffer - The data to compress.
+   * @param opts - The zlib options to apply for this operation.
+   * @param cb - Called with the resulting `Buffer`, or with an error if the operation fails.
+   */
   export function deflateRaw(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
   export function deflateRaw(buffer: ZlibInput, cb: ZlibCallback): void
 
+  /**
+   * Decompress `buffer` with raw inflate, without a zlib header, calling `cb` with the resulting `Buffer`.
+   * @param buffer - The data to decompress.
+   * @param opts - The zlib options to apply for this operation.
+   * @param cb - Called with the resulting `Buffer`, or with an error if the operation fails.
+   */
   export function inflateRaw(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
   export function inflateRaw(buffer: ZlibInput, cb: ZlibCallback): void
 
+  /**
+   * Compress `buffer` as gzip, calling `cb` with the resulting `Buffer`.
+   * @param buffer - The data to compress.
+   * @param opts - The zlib options to apply for this operation.
+   * @param cb - Called with the resulting `Buffer`, or with an error if the operation fails.
+   */
   export function gzip(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
   export function gzip(buffer: ZlibInput, cb: ZlibCallback): void
 
+  /**
+   * Decompress `buffer` as gzip, calling `cb` with the resulting `Buffer`.
+   * @param buffer - The data to decompress.
+   * @param opts - The zlib options to apply for this operation.
+   * @param cb - Called with the resulting `Buffer`, or with an error if the operation fails.
+   */
   export function gunzip(buffer: ZlibInput, opts: ZlibOptions, cb: ZlibCallback): void
   export function gunzip(buffer: ZlibInput, cb: ZlibCallback): void
 
+  /**
+   * Synchronously compress `buffer` with deflate and return the resulting `Buffer`.
+   * @param buffer - The data to compress; a string is converted to a `Buffer`.
+   * @param opts - The zlib options to apply for this operation.
+   * @throws {LIMIT_EXCEEDED} the output exceeded `maxOutputLength`.
+   * @throws {ZlibError} the underlying zlib operation failed; `code` identifies the failure.
+   */
   export function deflateSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer
+  /**
+   * Synchronously decompress `buffer` with inflate and return the resulting `Buffer`.
+   * @param buffer - The data to decompress; a string is converted to a `Buffer`.
+   * @param opts - The zlib options to apply for this operation.
+   * @throws {LIMIT_EXCEEDED} the output exceeded `maxOutputLength`.
+   * @throws {ZlibError} the underlying zlib operation failed; `code` (such as `DATA_ERROR`) identifies the failure.
+   */
   export function inflateSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer
+  /**
+   * Synchronously compress `buffer` with raw deflate, without a zlib header, and return the resulting `Buffer`.
+   * @param buffer - The data to compress; a string is converted to a `Buffer`.
+   * @param opts - The zlib options to apply for this operation.
+   * @throws {LIMIT_EXCEEDED} the output exceeded `maxOutputLength`.
+   * @throws {ZlibError} the underlying zlib operation failed; `code` identifies the failure.
+   */
   export function deflateRawSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer
+  /**
+   * Synchronously decompress `buffer` with raw inflate, without a zlib header, and return the resulting `Buffer`.
+   * @param buffer - The data to decompress; a string is converted to a `Buffer`.
+   * @param opts - The zlib options to apply for this operation.
+   * @throws {LIMIT_EXCEEDED} the output exceeded `maxOutputLength`.
+   * @throws {ZlibError} the underlying zlib operation failed; `code` (such as `DATA_ERROR`) identifies the failure.
+   */
   export function inflateRawSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer
+  /**
+   * Synchronously compress `buffer` as gzip and return the resulting `Buffer`.
+   * @param buffer - The data to compress; a string is converted to a `Buffer`.
+   * @param opts - The zlib options to apply for this operation.
+   * @throws {LIMIT_EXCEEDED} the output exceeded `maxOutputLength`.
+   * @throws {ZlibError} the underlying zlib operation failed; `code` identifies the failure.
+   */
   export function gzipSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer
+  /**
+   * Synchronously decompress `buffer` as gzip and return the resulting `Buffer`.
+   * @param buffer - The data to decompress; a string is converted to a `Buffer`.
+   * @param opts - The zlib options to apply for this operation.
+   * @throws {LIMIT_EXCEEDED} the output exceeded `maxOutputLength`.
+   * @throws {ZlibError} the underlying zlib operation failed; `code` (such as `DATA_ERROR`) identifies the failure.
+   */
   export function gunzipSync(buffer: ZlibInput, opts?: ZlibOptions): Buffer
 }
 

--- a/lib/constants.d.ts
+++ b/lib/constants.d.ts
@@ -1,3 +1,4 @@
+/** Zlib-related constants such as flush modes, compression levels, strategies, and chunk/window/memory-level bounds. */
 declare const constants: {
   Z_NO_FLUSH: number
   Z_PARTIAL_FLUSH: number

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -8,8 +8,11 @@ type ZlibErrorCode =
   | 'UNKNOWN_ERROR'
   | 'LIMIT_EXCEEDED'
 
+/** An error thrown by a zlib operation, carrying a `code` identifying the underlying zlib failure (such as `DATA_ERROR` or `MEM_ERROR`). */
 declare class ZlibError extends Error {
+  /** The zlib error code identifying the failure. */
   readonly code: ZlibErrorCode
+  /** Always `'ZlibError'`. */
   readonly name: 'ZlibError'
 }
 


### PR DESCRIPTION
## Document the public API as TSDoc

Adds TSDoc — `@param` / `@returns` / `@throws` tags plus member descriptions — to the shipped `.d.ts`, and regenerates the README `## API` section. Everything is derived from the existing type declarations and this module's own `index.js`/`lib` source; there are no AI-authored behavioral claims.

Produced by the [`pear-docs`](https://github.com/holepunchto/pear-docs) `bare-refgen` tooling, which documents the Bare module APIs from their type declarations. The README `## API` block is wrapped in `<!-- bare-refgen:api start/end -->` markers so it can be regenerated in place without disturbing surrounding prose.

Reviewed against source; happy to adjust wording, scope, or split as you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
